### PR TITLE
Notes at bio top optionally + msbuild changes

### DIFF
--- a/FriendNotes.csproj
+++ b/FriendNotes.csproj
@@ -1,93 +1,93 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6FA4995B-F9EB-43C8-8D7B-D5E7D015A805}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FriendNotes</RootNamespace>
     <AssemblyName>FriendNotes</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+
+  <PropertyGroup>
+    <VRCPath Condition="Exists('C:/Program Files (x86)/Steam/steamapps/common/VRChat/')">C:/Program Files (x86)/Steam/steamapps/common/VRChat/</VRCPath>
+    <VRCPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/VRChat/')">$(HOME)/.steam/steam/steamapps/common/VRChat/</VRCPath>
+
+    <GameRefsPath>Libs/</GameRefsPath>
+    <GameRefsPath Condition="Exists('$(VRCPath)MelonLoader/Managed/')">$(VRCPath)MelonLoader/Managed/</GameRefsPath>
+
+    <VRCModRefsPath>Libs/</VRCModRefsPath>
+    <VRCModRefsPath Condition="Exists('$(VRCPath)Mods/')">$(VRCPath)Mods/</VRCModRefsPath> 
+  </PropertyGroup> 
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Assembly-CSharp">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(GameRefsPath)Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Il2Cppmscorlib, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Il2Cppmscorlib">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
+      <HintPath>$(GameRefsPath)Il2Cppmscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="Il2CppSystem.Core, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Il2CppSystem.Core">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\Il2CppSystem.Core.dll</HintPath>
+      <HintPath>$(GameRefsPath)Il2CppSystem.Core.dll</HintPath>
     </Reference>
     <Reference Include="MelonLoader">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\MelonLoader.dll</HintPath>
+      <HintPath>Libs/MelonLoader.dll</HintPath>
+      <HintPath Condition="Exists('$(VRCPath)MelonLoader/MelonLoader.dll')">$(VRCPath)MelonLoader/MelonLoader.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\IIS\Microsoft Web Deploy V3\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(GameRefsPath)Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="UIExpansionKit">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\Mods\UIExpansionKit.dll</HintPath>
+      <HintPath>$(VRCModRefsPath)UIExpansionKit.dll</HintPath>
     </Reference>
-    <Reference Include="UnhollowerBaseLib, Version=0.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="UnhollowerBaseLib">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
+      <HintPath>$(GameRefsPath)UnhollowerBaseLib.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.TextMeshPro, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Unity.TextMeshPro">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>$(GameRefsPath)Unity.TextMeshPro.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="UnityEngine.CoreModule">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(GameRefsPath)UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UI, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="UnityEngine.UI">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(GameRefsPath)UnityEngine.UI.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UIModule, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="UnityEngine.UIModule">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(GameRefsPath)UnityEngine.UIModule.dll</HintPath>
     </Reference>
-    <Reference Include="VRCCore-Standalone, Version=3.7.1.6, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="VRCCore-Standalone">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\VRCCore-Standalone.dll</HintPath>
+      <HintPath>$(GameRefsPath)VRCCore-Standalone.dll</HintPath>
     </Reference>
     <Reference Include="VRChatUtilityKit">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\VRChat\Mods\VRChatUtilityKit.dll</HintPath>
+      <HintPath>$(VRCModRefsPath)VRChatUtilityKit.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Extensions.cs" />
-    <Compile Include="FriendNotes.cs" />
-    <Compile Include="Importer.cs" />
-    <Compile Include="NetworkManagerHooks.cs" />
-    <Compile Include="UserNote.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # FriendNotes
-Adds notes in social menu and below nameplate.<br>
-Option to log date and time when you friend people!<br>
-### Notes
+
+Adds notes in social menu and below nameplate.
+Option to log date and time when you friend people!
+
+## Notes
+
 * UIExpansion Kit and VRChatUtilityKit required
 * You can change the date format, check out [this page](https://www.c-sharpcorner.com/blogs/date-and-time-format-in-c-sharp-programming1) for syntax
 * You can add notes to anyone, not just friends
 * Notes are saved in `VRChat/UserData/FriendNotes.json`
-### Credit
+
+## Credit
+
 * knah for UIExpansion Kit and NetworkManagerHooks class
 * loukylor for AddFriend patch
 * Bluscream for [#3](https://github.com/markviews/FriendNotes/pull/3)
 
-![](https://i.ibb.co/5858tpJ/2021-06-14-18-39-12.png)
-![](https://i.ibb.co/bL2fDjG/2021-05-22-21-22-31.png)
+![example nameplate](https://i.ibb.co/5858tpJ/2021-06-14-18-39-12.png)
+![outdated example menu text](https://i.ibb.co/bL2fDjG/2021-05-22-21-22-31.png)


### PR DESCRIPTION
This change would add an option to show the notes before the actual bio, with a preference to toggle it that would default to the current behavior of showing the bio first.

Also the changes from my main branch, which include some small readme markdown formatting cleanup, and additionally re-writing most of the `.csproj` file to allow building the project on linux. The changes would make msbuild now look for the reference dll files from standard filepaths, and default to a local `Libs` folder in case none of the standard paths existed. I don't see why building still wouldn't work on Windows, but I do admit that I didn't bother testing it.